### PR TITLE
Add option to hide Add New row to Aftership Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ resources:
 
 ## Options
 
-| Name   | Type   | Requirement  | Description                                                                           |
-| ------ | ------ | ------------ | ------------------------------------------------------------------------------------- |
-| type   | string | **Required** | `custom:aftership-card`                                                               |
-| entity | string | **Required** | [Aftership](https://www.home-assistant.io/components/sensor.aftership/) sensor entity |
-| title  | string | **Optional** | Card title `Aftership`                                                                |
+| Name     | Type   | Requirement  | Description                                                                           |
+| -------- | ------ | ------------ | ------------------------------------------------------------------------------------- |
+| type     | string | **Required** | `custom:aftership-card`                                                               |
+| entity   | string | **Required** | [Aftership](https://www.home-assistant.io/components/sensor.aftership/) sensor entity |
+| title    | string | **Optional** | Card title `Aftership`                                                                |
+| show_add | bool   | **Optional** | Show fields to add a new package to track                                             |
 
 ## Usage
 

--- a/src/aftership-card.ts
+++ b/src/aftership-card.ts
@@ -149,23 +149,38 @@ export class AftershipCard extends LitElement {
               </paper-item>
             `,
         )}
-        <paper-item>
-          <paper-item-body>
-            <ha-icon class="addButton" @click=${this._addItem} icon="hass:plus" title="Add Tracking"> </ha-icon>
-          </paper-item-body>
-          <paper-item-body>
-            <paper-input no-label-float placeholder="Title" @keydown=${this._addKeyPress} id="title"></paper-input>
-          </paper-item-body>
-          <paper-item-body>
-            <paper-input
-              no-label-float
-              placeholder="Tracking"
-              @keydown=${this._addKeyPress}
-              id="tracking"
-              required
-            ></paper-input>
-          </paper-item-body>
-        </paper-item>
+        ${this._config.show_add === false
+          ? delivered.length === 0 && intransit.length === 0
+            ? html`
+                <paper-item>
+                  Not tracking any packages right now
+                </paper-item>
+              `
+            : null
+          : html`
+              <paper-item>
+                <paper-item-body>
+                  <ha-icon class="addButton" @click=${this._addItem} icon="hass:plus" title="Add Tracking"> </ha-icon>
+                </paper-item-body>
+                <paper-item-body>
+                  <paper-input
+                    no-label-float
+                    placeholder="Title"
+                    @keydown=${this._addKeyPress}
+                    id="title"
+                  ></paper-input>
+                </paper-item-body>
+                <paper-item-body>
+                  <paper-input
+                    no-label-float
+                    placeholder="Tracking"
+                    @keydown=${this._addKeyPress}
+                    id="tracking"
+                    required
+                  ></paper-input>
+                </paper-item-body>
+              </paper-item>
+            `}
       </ha-card>
     `;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface AftershipCardConfig {
   type: string;
   entity: string;
   title?: string;
+  show_add?: boolean;
 }
 
 export interface Tracking {


### PR DESCRIPTION
Added an option to hide the Add New row in the card in order to use it on a non-interactive Dashboard.

If there are tracking numbers on the card, it just hides the last (Add new) row. (I tested this part worked correctly, but would rather not post an screenshot that includes my tracking numbers)

If the card has no tracking numbers displayed. It will show text that says `Not tracking any packages right now`

